### PR TITLE
Add support for .ts extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const vslog = vscode.window.createOutputChannel("cucumber-gotostep");
+
 function getListOfFiles(myPath) {
     const result = [];
     const getAllFiles = (myPath) => {
@@ -12,11 +14,13 @@ function getListOfFiles(myPath) {
                 if (fs.lstatSync(curPath).isDirectory()) {
                     getAllFiles(curPath);
                 } else {
-                    if (path.extname(curPath) == '.js') {
+                    if (path.extname(curPath) === '.js' || path.extname(curPath) === '.ts') {
                         result.push(curPath);
                     }
                 }
             });
+        } else {
+            vslog.appendLine(`${module.id}.getListOfFiles(myPath): PATH DOES NOT EXIST: ${myPath}`);
         }
     };
     getAllFiles(myPath);
@@ -35,7 +39,7 @@ function getStepDef(files) {
         lines.forEach((i, line) => {
             if (i.indexOf('(/^') >= 0) {
                 result.push({
-                    regex: i.substring(i.indexOf('(/^') + 3, i.indexOf('$/,')),
+                    regex: i.substring(i.indexOf('/^') + 2, i.indexOf('$/,')),
                     file: file,
                     line: line
                 });
@@ -60,25 +64,33 @@ async function goToDef () {
         return;
     }
 
-    const step = editor.document.lineAt(editor.selection.active.line).text.trim();
+    // Skip the given/when/then 1st word from the line
+    const step = editor.document.lineAt(editor.selection.active.line).text.trim().split(' ').slice(1, +Infinity).join(' ');
     const paths = getPathToSrc();
     const filesarray = getListOfFiles(paths);
     const steps = getStepDef(filesarray);
     const result = steps.find((elem) => {
-        return step.search(elem.regex) >= 0;
+        try {
+            const re = new RegExp(elem.regex, 'g');
+            return re.test(step);
+        } catch (ex) {
+            vslog.appendLine(`goToDef() - EXCEPTION `, ex);
+            return false;
+        }
     });
 
-    const doc = await vscode.workspace.openTextDocument(result.file);
-    const textEditor = await vscode.window.showTextDocument(doc);
-    scrollToNewPositon(textEditor, result.line);
+    if (result) {
+        const doc = await vscode.workspace.openTextDocument(result.file, {preserveFocus: true, pinned: true});
+        const textEditor = await vscode.window.showTextDocument(doc);
+        scrollToNewPositon(textEditor, result.line);
+    }
 }
 
 
 export function activate(context: vscode.ExtensionContext) {
-
     const disposable = vscode.commands.registerCommand('extension.goToDef', goToDef);
-
     context.subscriptions.push(disposable);
+    vslog.appendLine(`Cucumber Goto Step is active!`);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
Provides slightly better regex match for steps; supports .ts extension, and leverages vscode logging